### PR TITLE
事業所取得処理を2020/12提供予定の新API仕様でcall。

### DIFF
--- a/src/Freee.Accounting/Api/CompaniesApi.cs
+++ b/src/Freee.Accounting/Api/CompaniesApi.cs
@@ -348,6 +348,7 @@ namespace Freee.Accounting.Api
             var localVarAccept = Freee.Accounting.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
+            localVarRequestOptions.HeaderParameters.Add("X-Api-Version", "2020-06-15");
 
             // authentication (oauth2) required
             // oauth required
@@ -403,7 +404,8 @@ namespace Freee.Accounting.Api
             
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
+            localVarRequestOptions.HeaderParameters.Add("X-Api-Version", "2020-06-15");
 
             // authentication (oauth2) required
             // oauth required
@@ -511,6 +513,8 @@ namespace Freee.Accounting.Api
                 localVarRequestOptions.QueryParameters.Add(Freee.Accounting.Client.ClientUtils.ParameterToMultiMap("", "walletables", walletables));
             }
 
+            localVarRequestOptions.HeaderParameters.Add("X-Api-Version", "2020-06-15");
+
             // authentication (oauth2) required
             // oauth required
             if (!String.IsNullOrEmpty(this.Configuration.AccessToken))
@@ -617,6 +621,8 @@ namespace Freee.Accounting.Api
             {
                 localVarRequestOptions.QueryParameters.Add(Freee.Accounting.Client.ClientUtils.ParameterToMultiMap("", "walletables", walletables));
             }
+
+            localVarRequestOptions.HeaderParameters.Add("X-Api-Version", "2020-06-15");
 
             // authentication (oauth2) required
             // oauth required

--- a/src/Freee.Accounting/Models/CompaniesShowResponseCompany.cs
+++ b/src/Freee.Accounting/Models/CompaniesShowResponseCompany.cs
@@ -21,6 +21,7 @@ using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using OpenAPIDateConverter = Freee.Accounting.Client.OpenAPIDateConverter;
+using static Freee.Accounting.Models.Invoice;
 
 namespace Freee.Accounting.Models
 {
@@ -320,7 +321,7 @@ namespace Freee.Accounting.Models
         /// <param name="industryCode">コード（transport_delivery: 輸送業/配送業、delivery: バイク便等の配達業、other_transportation_logistics: その他の運輸業、物流業） (required).</param>
         /// <param name="workflowSetting">仕訳承認フロー（enable: 有効、 disable: 無効） (required).</param>
         /// <param name="usePartnerCode">取引先コードの利用設定（true: 有効、 false: 無効） (required).</param>
-        public CompaniesShowResponseCompany(int id = default(int), string name = default(string), string nameKana = default(string), string displayName = default(string), int taxAtSourceCalcType = default(int), string contactName = default(string), int? headCount = default(int?), string corporateNumber = default(string), TxnNumberFormatEnum txnNumberFormat = default(TxnNumberFormatEnum), int defaultWalletAccountId = default(int), bool privateSettlement = default(bool), int minusFormat = default(int), RoleEnum role = default(RoleEnum), string phone1 = default(string), string phone2 = default(string), string fax = default(string), string zipcode = default(string), int prefectureCode = default(int), string streetName1 = default(string), string streetName2 = default(string), int invoiceLayout = default(int), int invoiceStyle = default(int), int amountFraction = default(int), IndustryClassEnum industryClass = default(IndustryClassEnum), IndustryCodeEnum industryCode = default(IndustryCodeEnum), WorkflowSettingEnum workflowSetting = default(WorkflowSettingEnum), bool usePartnerCode = default(bool))
+        public CompaniesShowResponseCompany(int id = default(int), string name = default(string), string nameKana = default(string), string displayName = default(string), int taxAtSourceCalcType = default(int), string contactName = default(string), int? headCount = default(int?), string corporateNumber = default(string), TxnNumberFormatEnum txnNumberFormat = default(TxnNumberFormatEnum), int defaultWalletAccountId = default(int), bool privateSettlement = default(bool), int minusFormat = default(int), RoleEnum role = default(RoleEnum), string phone1 = default(string), string phone2 = default(string), string fax = default(string), string zipcode = default(string), int prefectureCode = default(int), string streetName1 = default(string), string streetName2 = default(string), InvoiceLayoutEnum invoiceLayout = default(InvoiceLayoutEnum), int invoiceStyle = default(int), int amountFraction = default(int), IndustryClassEnum industryClass = default(IndustryClassEnum), IndustryCodeEnum industryCode = default(IndustryCodeEnum), WorkflowSettingEnum workflowSetting = default(WorkflowSettingEnum), bool usePartnerCode = default(bool))
         {
             this.Id = id;
             // to ensure "name" is required (not null)
@@ -490,11 +491,11 @@ namespace Freee.Accounting.Models
         public string StreetName2 { get; set; }
 
         /// <summary>
-        /// レイアウト(0: レイアウト1, 1:レイアウト2, 3:封筒1, 4:レイアウト3(繰越金額欄あり), 5: 封筒2(繰越金額欄あり))
+        /// レイアウト(default_classic:レイアウト１/クラシック (デフォルト), standard_classic:レイアウト２/クラシック, envelope_classic:封筒１/クラシック, carried_forward_standard_classic:レイアウト３（繰越金額欄あり）/クラシック, carried_forward_envelope_classic:封筒２（繰越金額欄あり）/クラシック, default_modern:レイアウト１/モダン, standard_modern:レイアウト２/モダン, envelope_modern:封筒/モダン)
         /// </summary>
-        /// <value>レイアウト(0: レイアウト1, 1:レイアウト2, 3:封筒1, 4:レイアウト3(繰越金額欄あり), 5: 封筒2(繰越金額欄あり))</value>
+        /// <value>default_classic:レイアウト１/クラシック (デフォルト), standard_classic:レイアウト２/クラシック, envelope_classic:封筒１/クラシック, carried_forward_standard_classic:レイアウト３（繰越金額欄あり）/クラシック, carried_forward_envelope_classic:封筒２（繰越金額欄あり）/クラシック, default_modern:レイアウト１/モダン, standard_modern:レイアウト２/モダン, envelope_modern:封筒/モダン</value>
         [DataMember(Name="invoice_layout", EmitDefaultValue=false)]
-        public int InvoiceLayout { get; set; }
+        public InvoiceLayoutEnum InvoiceLayout { get; set; }
 
         /// <summary>
         /// スタイル(0: クラシック, 1: モダン)


### PR DESCRIPTION
はじめまして。

普段から本SDKを愛用させていただいております。
https://developer.freee.co.jp/release-note/2948

上記新API仕様変更に伴うSDKの改修をしています。
全ての機能を利用しているわけではないため、部分的に改修をしているのですが、これを
本SDKに反映させたい場合どうあるべきかちょっと分からず相談を兼ねて試験的にプルリクエストを投げます。

とりあえず本プルリクエストでは、事業所情報取得時のレスポンス(invoice_layout)が変わっている部分のみの改修となります。
GET Companiesだけ新API仕様でcallする形になってしまうので、こういった部分的なプルリクエストは微妙でしょうか。

本来はApiClient.Version.csあたりに新API call用のヘッダをつけて一律変更対応するのが良いのかなと思いつつ、
こちらで行っている改修は部分的なので、全ては対応できずといった具合です。

そもそも本SDKの新API仕様対応を今ではなくまだ先(12月までを目途に行う)などといった考え方もあるかと思いますので、
そのあたりのご意見をお聞かせ願えれば幸いです。

突然のプルリクエスト失礼しました。
