### PR TITLE
CreateDealParamsPayments クラスのコンストラクタのdateがnullの時の例外処理を削除

### DIFF
--- a/src/Freee.Accounting/Models/CreateDealParamsPayments.cs
+++ b/src/Freee.Accounting/Models/CreateDealParamsPayments.cs
@@ -86,8 +86,7 @@ namespace Freee.Accounting.Models
             this.Amount = amount;
             this.FromWalletableId = fromWalletableId;
             this.FromWalletableType = fromWalletableType;
-            // to ensure "date" is required (not null)
-            this.Date = date ?? throw new ArgumentNullException("date is a required property for CreateDealParamsPayments and cannot be null");;
+            this.Date = date;
         }
         
         /// <summary>


### PR DESCRIPTION
### 事象
`CreateDealParamsPayments` クラスを（コンストラクタではなく）プロパティを使って `new` すると例外処理が発生する

```cs
// NG: 例外が発生する
// date is a required property for CreateDealParamsPayments and cannot be null
new CreateDealParamsPayments
{
    Amount = amount,
    FromWalletableId = walletableId,
    FromWalletableType= walletableType,
    Date = inputDate
}

// OK
new CreateDealParamsPayments
(
    amount,
    walletableId,
    walletableType,
    inputDate
)
```
### 修正内容
コンストラクタの `date` の例外処理を削除

